### PR TITLE
add automaticlly a super user with name:givit pass:givit

### DIFF
--- a/givitsite/friendreq/migrations/createsuperuser.py
+++ b/givitsite/friendreq/migrations/createsuperuser.py
@@ -1,0 +1,31 @@
+import os
+
+from django.db import migrations
+from django.db.utils import IntegrityError
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    def generate_superuser(apps, schema_editor):
+        from django.contrib.auth.models import User
+
+        DJANGO_SU_NAME = os.environ.get('DJANGO_SU_NAME', 'givit')
+        DJANGO_SU_EMAIL = os.environ.get('DJANGO_SU_EMAIL', 'givit@example.com')
+        DJANGO_SU_PASSWORD = os.environ.get('DJANGO_SU_PASSWORD', 'givit')
+
+        try:
+            superuser = User.objects.create_superuser(
+                username=DJANGO_SU_NAME,
+                email=DJANGO_SU_EMAIL,
+                password=DJANGO_SU_PASSWORD)
+
+            superuser.save()
+        except IntegrityError:
+            pass
+
+    operations = [
+        migrations.RunPython(generate_superuser),
+    ]


### PR DESCRIPTION
In order to use the admin app on the Django app, one must create a superuser.
The added code will generate a new superuser automatically when we use the command "migrate".
therefore, when the bootstrap.sh will finish its run we will be able to use the admin functionality.
this PR solving #38 issue
