### PR TITLE
Manage adding items by logging module

### DIFF
--- a/givitsite/gatherer/agora.py
+++ b/givitsite/gatherer/agora.py
@@ -9,6 +9,9 @@ from datetime import datetime
 from friendreq.models import ItemRequest
 from friendreq.models import ITEM_CHOICES
 from friendreq.models import ItemsFound
+import logging
+
+logger = logging.getLogger('django')
 
 
 def givit_main():
@@ -27,9 +30,9 @@ def givit_main():
         if len(url_list) > 0:
             for url in url_list:
                 if not found.filter(url=url).exists():
-                    print(item.item)
                     counter += 1
-                    print(str(counter) + " new item added")
+                    logger.info(iseek_dict_eng.get(item.item) +
+                                ": " + str(counter) + " new item added")
                     newFound = ItemsFound(
                         request_id=item, url=url, picture=url, city=item.region, title=iseek_dict_eng.get(item.item))
                     newFound.save()

--- a/givitsite/givitsite/settings.py
+++ b/givitsite/givitsite/settings.py
@@ -134,3 +134,38 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'static')
 ]
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'agora': {
+            'format': '%(levelname)s %(asctime)s %(message)s'
+        },
+    },
+    'handlers': {
+        'file': {
+            'level': 'INFO',
+            'class': 'logging.FileHandler',
+            'formatter': 'agora',
+            'filename': './logs/agora.log',
+        },
+        'django.server': {
+            'level': 'INFO',
+            'class': 'logging.FileHandler',
+            'filename': './logs/server.log',
+        },
+    },
+    'loggers': {
+        'django.server': {
+            'handlers': ['django.server'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'django': {
+            'handlers': ['file'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+    },
+}


### PR DESCRIPTION
Our app now handle all the added items in agora.log using django logging module.
the commit:
1. we add to settings.py logging module and 2 loggers- for agora and for requests.
2. add logs directory that include all the log files.

fixed: #62
fixes: #100