### PR TITLE
implement filters in coordinator page

### DIFF
--- a/givitsite/coordinate/models.py
+++ b/givitsite/coordinate/models.py
@@ -45,4 +45,4 @@ class CoordinationForm(forms.ModelForm):
 
 def close_related_request(request):
     ItemRequest.objects.filter(
-        id=request.POST['request_id']).update(status='close')
+        id=request.POST['request_id']).update(status='closed')

--- a/givitsite/coordinate/views.py
+++ b/givitsite/coordinate/views.py
@@ -1,19 +1,17 @@
+from accounts.models import Profile
 from django.contrib.auth.models import User
 from django.shortcuts import redirect, render
-from friendreq.models import ItemRequest, ItemsFound
-
+from friendreq.models import ItemRequest, ItemsFound, REGION_CHOICES, ITEM_CHOICES
 from .models import CoordinationForm, close_related_request
 
 
 def coordinator_create_view(request):
     if request.method == 'GET':
         form = CoordinationForm()
-        matchedItems = ItemsFound.objects.filter(match=True)
-        openRequests = ItemRequest.objects.filter(status='in_process')
-        users = User.objects.all()
+        matchedItems, openRequests = get_data_query_sets(request)
+        item_choices_list, region_choices_list = get_filters_as_lists()
 
-        return render(request, 'coordinator.html',
-                      {'form': form, 'matchedItems': matchedItems, 'openRequests': openRequests, 'users': users})
+        return render(request, 'coordinator.html',{'form': form, 'matchedItems': matchedItems, 'openRequests': openRequests, 'region_choices': region_choices_list, 'item_choices': item_choices_list})   
     else:
         form = CoordinationForm(request.POST or None)
         if form.is_valid():
@@ -22,3 +20,29 @@ def coordinator_create_view(request):
             close_related_request(request)
 
         return redirect('/coordinate')
+
+#Convert the tupple list to a string list so it can be rendered in the template
+def get_filters_as_lists():
+        item_choices_list = [] 
+        region_choices_list = []
+
+        for region in REGION_CHOICES: 
+            region_choices_list.append(region[1])
+        for item in ITEM_CHOICES:
+            item_choices_list.append(item[1])
+        return item_choices_list, region_choices_list
+   
+def get_data_query_sets(request):
+
+    matchedItems = ItemsFound.objects.filter(match=True)
+    openRequests = ItemRequest.objects.filter(status='in_process')
+
+    item_filter = request.GET.get('item')
+    pickup_city_filter = request.GET.get('city_pickup')
+
+    if item_filter is not None and item_filter != "":
+            matchedItems = matchedItems.filter(title = item_filter)
+    if pickup_city_filter is not None and pickup_city_filter  != "":
+        matchedItems = matchedItems.filter(city = pickup_city_filter)
+
+    return matchedItems, openRequests

--- a/givitsite/coordinate/views.py
+++ b/givitsite/coordinate/views.py
@@ -1,7 +1,7 @@
-from accounts.models import Profile
-from django.contrib.auth.models import User
 from django.shortcuts import redirect, render
-from friendreq.models import ItemRequest, ItemsFound, REGION_CHOICES, ITEM_CHOICES
+from friendreq.models import (ITEM_CHOICES, REGION_CHOICES, ItemRequest,
+                              ItemsFound)
+
 from .models import CoordinationForm, close_related_request
 
 
@@ -10,8 +10,15 @@ def coordinator_create_view(request):
         form = CoordinationForm()
         matchedItems, openRequests = get_data_query_sets(request)
         item_choices_list, region_choices_list = get_filters_as_lists()
+        render_dict = {
+            'form': form,
+            'matchedItems': matchedItems,
+            'openRequests': openRequests,
+            'region_choices': region_choices_list,
+            'item_choices': item_choices_list
+        }
 
-        return render(request, 'coordinator.html',{'form': form, 'matchedItems': matchedItems, 'openRequests': openRequests, 'region_choices': region_choices_list, 'item_choices': item_choices_list})   
+        return render(request, 'coordinator.html', render_dict)
     else:
         form = CoordinationForm(request.POST or None)
         if form.is_valid():
@@ -21,28 +28,25 @@ def coordinator_create_view(request):
 
         return redirect('/coordinate')
 
-#Convert the tupple list to a string list so it can be rendered in the template
+
 def get_filters_as_lists():
-        item_choices_list = [] 
-        region_choices_list = []
+    item_choices_list = []
+    region_choices_list = []
 
-        for region in REGION_CHOICES: 
-            region_choices_list.append(region[1])
-        for item in ITEM_CHOICES:
-            item_choices_list.append(item[1])
-        return item_choices_list, region_choices_list
-   
+    for region in REGION_CHOICES:
+        region_choices_list.append(region[1])
+    for item in ITEM_CHOICES:
+        item_choices_list.append(item[1])
+    return item_choices_list, region_choices_list
+
+
 def get_data_query_sets(request):
-
     matchedItems = ItemsFound.objects.filter(match=True)
     openRequests = ItemRequest.objects.filter(status='in_process')
-
     item_filter = request.GET.get('item')
     pickup_city_filter = request.GET.get('city_pickup')
-
     if item_filter is not None and item_filter != "":
-            matchedItems = matchedItems.filter(title = item_filter)
-    if pickup_city_filter is not None and pickup_city_filter  != "":
-        matchedItems = matchedItems.filter(city = pickup_city_filter)
-
+        matchedItems = matchedItems.filter(title=item_filter)
+    if (pickup_city_filter is not None) and (pickup_city_filter != ""):
+        matchedItems = matchedItems.filter(city=pickup_city_filter)
     return matchedItems, openRequests

--- a/givitsite/templates/coordinator.html
+++ b/givitsite/templates/coordinator.html
@@ -2,6 +2,27 @@
 
 {%block content%}
 
+     <div id="stripe" style="width:50%;">
+        <form method="GET">
+            <button type='submit' id="newColors" style="align-self:left">implement filters</button>
+            <span class="answer"></span>
+            <lable> Item type:  </lable>
+            <select id="itemButton" name="item" size="1" value="All" style="text-align-last:center; border:1ppx solid black;; display: inline-block; margin-left: 20ppx;">
+                <option value="" selected>All</option>
+                {% for item in item_choices %} 
+                    <option value="{{item}}">{{item}}</option>
+                {%endfor%}
+            </select>
+            <lable> city pick up:  </lable>
+            <select id="cityPickUpButton" name="city_pickup" size="1" style="text-align-last:center; border:1ppx solid black;; margin-left: 20ppx;">
+                <option value="" selected>All</option>
+                {% for city in region_choices %} 
+                    <option value="{{city}}">{{city}}</option>
+                {%endfor%}
+            </select>
+        </form>
+    </div>
+
 {% for item in matchedItems %}
     {% for request in openRequests %} 
        {% if item.request_id == request %} 


### PR DESCRIPTION
1. Add filter form to coordinator template.
2. Views page:
    - Create a new function - 'get_data_query_sets':
        >  Returns filtered query sets based on filter values in the GET request
   - Create a new function 'get_filters_as_lists' :
        > Extracts the values from the tuple lists REGION_CHOICES & ITEM_CHOICES into String lists.
        > This allows better rendering of the values in the filter select buttons.
3. Fix a small typo in coordinator/models/close_related_request


Fixes #61 




